### PR TITLE
Upgrade insightface

### DIFF
--- a/insightface_func/face_detect_crop_multi.py
+++ b/insightface_func/face_detect_crop_multi.py
@@ -62,7 +62,6 @@ class Face_detect_crop:
 
     def get(self, img, crop_size, max_num=0):
         bboxes, kpss = self.det_model.detect(img,
-                                             threshold=self.det_thresh,
                                              max_num=max_num,
                                              metric='default')
         if bboxes.shape[0] == 0:

--- a/insightface_func/face_detect_crop_multi.py
+++ b/insightface_func/face_detect_crop_multi.py
@@ -49,7 +49,7 @@ class Face_detect_crop:
 
 
     def prepare(self, ctx_id, det_thresh=0.5, det_size=(640, 640), mode ='None'):
-        self.det_thresh = det_thresh
+        self.det_model.det_thresh = det_thresh
         self.mode = mode
         assert det_size is not None
         print('set det-size:', det_size)

--- a/insightface_func/face_detect_crop_single.py
+++ b/insightface_func/face_detect_crop_single.py
@@ -62,7 +62,6 @@ class Face_detect_crop:
 
     def get(self, img, crop_size, max_num=0):
         bboxes, kpss = self.det_model.detect(img,
-                                             threshold=self.det_thresh,
                                              max_num=max_num,
                                              metric='default')
         if bboxes.shape[0] == 0:

--- a/insightface_func/face_detect_crop_single.py
+++ b/insightface_func/face_detect_crop_single.py
@@ -49,7 +49,7 @@ class Face_detect_crop:
 
 
     def prepare(self, ctx_id, det_thresh=0.5, det_size=(640, 640), mode ='None'):
-        self.det_thresh = det_thresh
+        self.det_model.det_thresh = det_thresh
         self.mode = mode
         assert det_size is not None
         print('set det-size:', det_size)

--- a/models/fs_model.py
+++ b/models/fs_model.py
@@ -61,7 +61,7 @@ class fsModel(BaseModel):
 
         # Id network
         netArc_checkpoint = opt.Arc_path
-        netArc_checkpoint = torch.load(netArc_checkpoint, map_location=torch.device("cpu"))
+        netArc_checkpoint = torch.load(netArc_checkpoint, map_location=torch.device("cpu"), weights_only=False)
         self.netArc = netArc_checkpoint
         self.netArc = self.netArc.to(device)
         self.netArc.eval()

--- a/util/reverse2original.py
+++ b/util/reverse2original.py
@@ -154,9 +154,9 @@ def reverse2wholeimage(b_align_crop_tenor_list,swaped_imgs, mats, crop_size, ori
         # target_image_parsing = postprocess(target_image, source_image, tgt_mask)
 
         if use_mask:
-            target_image = np.array(target_image, dtype=np.float) * 255
+            target_image = np.array(target_image, dtype=np.float32) * 255
         else:
-            target_image = np.array(target_image, dtype=np.float)[..., ::-1] * 255
+            target_image = np.array(target_image, dtype=np.float32)[..., ::-1] * 255
 
 
         img_mask_list.append(img_mask)
@@ -165,7 +165,7 @@ def reverse2wholeimage(b_align_crop_tenor_list,swaped_imgs, mats, crop_size, ori
 
     # target_image /= 255
     # target_image = 0
-    img = np.array(oriimg, dtype=np.float)
+    img = np.array(oriimg, dtype=np.float32)
     for img_mask, target_image in zip(img_mask_list, target_image_list):
         img = img_mask * target_image + (1-img_mask) * img
         


### PR DESCRIPTION
The following issue arises with `insightface==0.6.2` or below, including the recommended version (0.2.1).

```
ValueError: This ORT build has ['AzureExecutionProvider', 'CPUExecutionProvider'] enabled. Since ORT 1.9, you are required to explicitly set the providers parameter when instantiating InferenceSession. For example, onnxruntime.InferenceSession(..., providers=['AzureExecutionProvider', 'CPUExecutionProvider'], ...)
```

See:
- #445 

This issue is fixed by upgrading to `insightface==0.7` or above, but the following issue arises.

```
TypeError: RetinaFace.detect() got an unexpected keyword argument 'threshold'
```

This pull request fixes this second issue, which allows to use the latest version of `insightface` (0.7.3). 

Fix:
- #139
- #407 